### PR TITLE
Fix long texts leads to overflow

### DIFF
--- a/src/main/js/CollapsibleContainer.tsx
+++ b/src/main/js/CollapsibleContainer.tsx
@@ -21,9 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, {FC, useState} from "react";
+import React, { FC, useState } from "react";
 import styled from "styled-components";
-import {Icon, Notification} from "@scm-manager/ui-components";
+import { Icon } from "@scm-manager/ui-components";
 import EmptyMessage from "./EmptyMessage";
 
 type Props = {
@@ -56,7 +56,7 @@ const Separator = styled.hr`
   margin: 0.5rem 0;
 `;
 
-const CollapsibleContainer: FC<Props> = ({title, separatedEntries, emptyMessage, children}) => {
+const CollapsibleContainer: FC<Props> = ({ title, separatedEntries, emptyMessage, children }) => {
   const [collapsed, setCollapsed] = useState(false);
 
   const icon = collapsed ? "angle-right" : "angle-down";
@@ -76,9 +76,9 @@ const CollapsibleContainer: FC<Props> = ({title, separatedEntries, emptyMessage,
     <Container>
       <div className="has-cursor-pointer" onClick={() => setCollapsed(!collapsed)}>
         <Headline>
-          <Icon name={icon} color="default"/> {title}
+          <Icon name={icon} color="default" /> {title}
         </Headline>
-        <Separator/>
+        <Separator />
       </div>
       {content}
     </Container>

--- a/src/main/js/Home.tsx
+++ b/src/main/js/Home.tsx
@@ -39,11 +39,11 @@ const Home: FC<Props> = props => {
   return (
     <Page title={t("scm-landingpage-plugin.home.title")} subtitle={t("scm-landingpage-plugin.home.subtitle")}>
       <div className="columns">
-        <div className="column">
+        <div className="column is-half">
           <MyTasks links={props.links} />
           <MyData links={props.links} />
         </div>
-        <div className="column">
+        <div className="column is-half">
           <MyEvents links={props.links} />
         </div>
       </div>

--- a/src/main/js/data/FavoriteRepositoryCard.tsx
+++ b/src/main/js/data/FavoriteRepositoryCard.tsx
@@ -22,9 +22,10 @@
  * SOFTWARE.
  */
 import React, { FC } from "react";
-import { RepositoryDataType } from "../types";
-import { RepositoryEntry } from "@scm-manager/ui-components";
+import classNames from "classnames";
 import styled from "styled-components";
+import { RepositoryEntry } from "@scm-manager/ui-components";
+import { RepositoryDataType } from "../types";
 
 type Props = {
   data: RepositoryDataType;
@@ -32,18 +33,18 @@ type Props = {
 
 const RepositoryEntryWrapper = styled.div`
   .overlay-column {
-    width: calc(50% - 3rem);
+    width: calc(50% - 0.75rem);
 
     @media screen and (max-width: 768px) {
-      width: calc(100% - 1.5rem);
+      width: calc(100%);
     }
   }
 `;
 
 const FavoriteRepositoryCard: FC<Props> = ({ data }) => {
   return (
-    <div className={"card-columns is-multiline"}>
-      <RepositoryEntryWrapper className="box box-link-shadow column is-clipped">
+    <div className={classNames("columns", "card-columns")}>
+      <RepositoryEntryWrapper className={classNames("box", "box-link-shadow", "column", "is-clipped")}>
         <RepositoryEntry repository={data.repository} />
       </RepositoryEntryWrapper>
     </div>


### PR DESCRIPTION
## Proposed changes

Long texts, e.g. in the description of a repo, can lead to the page overflow on the landing page

### Your checklist for this pull request

- [x] PR is well described
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [ ] CHANGELOG.md updated
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
