### PR TITLE
Fix "change committed"-link in latest activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fix "change committed" link in the latest activities ([#21](https://github.com/scm-manager/scm-landingpage-plugin/pull/21))
+
 ## 1.3.0 - 2020-12-04
 ### Added
 - Add repository import event for successful and failed imports ([#19](https://github.com/scm-manager/scm-landingpage-plugin/pull/19))
@@ -13,13 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show landingpage for anonymous user ([#18](https://github.com/scm-manager/scm-landingpage-plugin/pull/18))
 
 ## 1.1.0 - 2020-07-03
-
 ### Added
 - Add repository renamed event [#14](https://github.com/scm-manager/scm-landingpage-plugin/pull/14)
 
 ### Fixed
 - Add permission check before accessing repository data ([#15](https://github.com/scm-manager/scm-landingpage-plugin/pull/15))
-
 
 ## 1.0.0 - 2020-06-04
 ### Fixed
@@ -35,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deleted repositories are now also removed from all users' favourites. ([#12](https://github.com/scm-manager/scm-landingpage-plugin/pull/12))
 
 ## 1.0.0-rc1 - 2020-04-14
-
 Initial release
 
 [1.0.0-rc1]: https://github.com/scm-manager/scm-landingpage-plugin/releases/tag/1.0.0-rc1

--- a/src/main/js/events/RepositoryPushEvent.tsx
+++ b/src/main/js/events/RepositoryPushEvent.tsx
@@ -45,7 +45,7 @@ const StyledGravatar = styled(AvatarImage)`
 const RepositoryPushEvent: MyEventComponent<RepositoryPushEventType> = ({ event }) => {
   const [t] = useTranslation("plugins");
 
-  const link = "/repo/" + event.repository + "/code/changesets";
+  const link = "/repo/" + event.repository + "/code/changesets/";
 
   const icon = binder.hasExtension("avatar.factory") ? (
     <StyledGravatar person={{ name: event.authorName, mail: event.authorMail }} />


### PR DESCRIPTION
## Proposed changes

Fix "change committed"-link in latest activities by adding ending slash to Repository Push Event link

### Your checklist for this pull request

- [x] PR is well described and the description can be used as commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [x] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
