### PR TITLE
Improve data fetching error display and redirect to landing page after changing the display settings

### DIFF
--- a/gradle/changelog/error_display_and_config_redirect.yaml
+++ b/gradle/changelog/error_display_and_config_redirect.yaml
@@ -1,0 +1,4 @@
+- type: fixed
+  description: Improve data fetching error display ([#58](https://github.com/scm-manager/scm-landingpage-plugin/pull/58))
+- type: fixed
+  description: Redirect to landing page after changing the display settings ([#58](https://github.com/scm-manager/scm-landingpage-plugin/pull/58))

--- a/src/main/js/CollapsibleContainer.tsx
+++ b/src/main/js/CollapsibleContainer.tsx
@@ -23,7 +23,7 @@
  */
 import React, { FC, useEffect, useState } from "react";
 import styled from "styled-components";
-import { devices, Icon, Tag } from "@scm-manager/ui-components";
+import { devices, ErrorNotification, Icon, Tag } from "@scm-manager/ui-components";
 import EmptyMessage from "./EmptyMessage";
 
 type Props = {
@@ -31,9 +31,10 @@ type Props = {
   separatedEntries: boolean;
   emptyMessage?: string;
   count?: number;
-  initiallyCollapsed?: boolean;
+  initiallyCollapsed?: boolean | null;
   onCollapseToggle?: (collapsed: boolean) => void;
   contentWrapper?: React.ElementType;
+  error?: Error | null;
 };
 
 const Container = styled.div`
@@ -66,7 +67,8 @@ const CollapsibleContainer: FC<Props> = ({
   emptyMessage,
   children,
   onCollapseToggle,
-  contentWrapper
+  contentWrapper,
+  error
 }) => {
   const [collapsed, setCollapsed] = useState<boolean>();
 
@@ -77,7 +79,9 @@ const CollapsibleContainer: FC<Props> = ({
 
   const icon = collapsed ? "angle-right" : "angle-down";
   let content = null;
-  if (!collapsed) {
+  if (error) {
+    content = <ErrorNotification error={error} />;
+  } else if (!collapsed) {
     const childArray = React.Children.toArray(children);
     if (!childArray || childArray.length === 0) {
       content = <EmptyMessage messageKey={emptyMessage} />;
@@ -92,6 +96,16 @@ const CollapsibleContainer: FC<Props> = ({
     }
   }
 
+  let headerSuffix;
+
+  if (!error) {
+    headerSuffix = (
+      <Tag color="info" className="ml-1">
+        <b className="is-size-6">{count || 0}</b>
+      </Tag>
+    );
+  }
+
   const handleCollapseToggle = () => {
     const newState = !collapsed;
     setCollapsed(newState);
@@ -102,10 +116,7 @@ const CollapsibleContainer: FC<Props> = ({
     <Container>
       <div className="has-cursor-pointer" onClick={handleCollapseToggle}>
         <Headline>
-          <Icon name={icon} color="default" /> {title}{" "}
-          <Tag color="info" className="ml-1">
-            <b className="is-size-6">{count || 0}</b>
-          </Tag>
+          <Icon name={icon} color="default" /> {title} {headerSuffix}
         </Headline>
         <Separator />
       </div>

--- a/src/main/js/config/ConfigPage.tsx
+++ b/src/main/js/config/ConfigPage.tsx
@@ -28,6 +28,7 @@ import { useTranslation } from "react-i18next";
 import { ExtensionProps } from "../data/MyData";
 import { useBinder } from "@scm-manager/ui-extensions";
 import { useDisabledCategories } from "./hooks";
+import { useHistory } from "react-router-dom";
 
 type DisplayOptionProps = {
   label: string;
@@ -45,6 +46,7 @@ const ConfigPage: FC = () => {
   const binder = useBinder();
   const [changedCategories, setChangedCategories] = useState<{ [key: string]: boolean }>({});
   const extensions: ExtensionProps[] = binder.getExtensions("landingpage.mydata");
+  const history = useHistory();
 
   const changeExtension = (category: string) => (enabled: boolean) => {
     const newValue = { ...changedCategories, [category]: enabled };
@@ -58,6 +60,7 @@ const ConfigPage: FC = () => {
   const submitChanges = () => {
     setCategories(changedCategories);
     setChangedCategories({});
+    setTimeout(() => history.push("/repos/"));
   };
 
   return (

--- a/src/main/js/data/MyData.tsx
+++ b/src/main/js/data/MyData.tsx
@@ -24,7 +24,7 @@
 import React, { FC, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { useIndexLinks } from "@scm-manager/ui-api";
-import { ErrorNotification, Loading, Notification } from "@scm-manager/ui-components";
+import { Loading, Notification } from "@scm-manager/ui-components";
 import { binder } from "@scm-manager/ui-extensions";
 import CollapsibleContainer from "../CollapsibleContainer";
 import { Link } from "@scm-manager/ui-types";
@@ -43,9 +43,10 @@ export type ExtensionProps = {
 type MyDataExtensionProps = {
   extension: ExtensionProps;
   data?: MyDataType[];
+  error?: Error | null;
 };
 
-const MyDataExtension: FC<MyDataExtensionProps> = ({ extension, data }) => {
+const MyDataExtension: FC<MyDataExtensionProps> = ({ extension, data, error }) => {
   const [t] = useTranslation("plugins");
   const disabled = useIsCategoryDisabled(extension.type);
   const [collapsed, setCollapsed] = useCollapsedState(extension.type);
@@ -61,6 +62,7 @@ const MyDataExtension: FC<MyDataExtensionProps> = ({ extension, data }) => {
         count={data?.length}
         initiallyCollapsed={collapsed}
         onCollapseToggle={setCollapsed}
+        error={error}
       >
         {(data?.length || 0) > 0 ? (
           data?.map((dataEntry, key) => <>{extension.render(dataEntry, key)}</>)
@@ -78,17 +80,13 @@ const MyData: FC = () => {
 
   const renderExtension: (extension: ExtensionProps) => any = extension => {
     const dataForExtension = data?._embedded.data.filter(entry => entry.type === extension.type);
-    return <MyDataExtension extension={extension} data={dataForExtension} />;
+    return <MyDataExtension extension={extension} data={dataForExtension} error={error} />;
   };
 
   const extensions: ExtensionProps[] = binder.getExtensions("landingpage.mydata");
 
   if (!extensions.length) {
     return null;
-  }
-
-  if (error) {
-    return <ErrorNotification error={error} />;
   }
 
   if (isLoading) {

--- a/src/main/js/events/MyEvents.tsx
+++ b/src/main/js/events/MyEvents.tsx
@@ -24,7 +24,7 @@
 import React, { FC } from "react";
 import { useTranslation } from "react-i18next";
 import CollapsibleContainer from "../CollapsibleContainer";
-import { ErrorNotification, Loading } from "@scm-manager/ui-components";
+import { Loading } from "@scm-manager/ui-components";
 import MyEvent from "./MyEvent";
 import { Link } from "@scm-manager/ui-types";
 import { useMyEvents } from "./useMyEvents";
@@ -43,10 +43,6 @@ const MyEvents: FC = () => {
     return null;
   }
 
-  if (error) {
-    return <ErrorNotification error={error} />;
-  }
-
   if (isLoading) {
     return <Loading />;
   }
@@ -60,6 +56,7 @@ const MyEvents: FC = () => {
       initiallyCollapsed={collapsed}
       onCollapseToggle={setCollapsed}
       contentWrapper={ScrollContainer}
+      error={error}
     >
       {data?._embedded?.events?.map((event, index) => (
         <MyEvent key={index} event={event} />

--- a/src/main/js/tasks/MyTasks.tsx
+++ b/src/main/js/tasks/MyTasks.tsx
@@ -24,7 +24,7 @@
 import React, { FC } from "react";
 import CollapsibleContainer from "../CollapsibleContainer";
 import { useTranslation } from "react-i18next";
-import { ErrorNotification, Loading } from "@scm-manager/ui-components";
+import { Loading } from "@scm-manager/ui-components";
 import MyTask from "./MyTask";
 import { Link } from "@scm-manager/ui-types";
 import { useMyTasks } from "./useMyTasks";
@@ -42,10 +42,6 @@ const MyTasks: FC = () => {
     return null;
   }
 
-  if (error) {
-    return <ErrorNotification error={error} />;
-  }
-
   if (isLoading) {
     return <Loading />;
   }
@@ -58,6 +54,7 @@ const MyTasks: FC = () => {
       count={data?._embedded?.tasks?.length}
       initiallyCollapsed={collapsed}
       onCollapseToggle={setCollapsed}
+      error={error}
     >
       {data?._embedded?.tasks.map((task, key) => (
         <MyTask key={key} task={task} />

--- a/src/main/js/tips/MyTips.tsx
+++ b/src/main/js/tips/MyTips.tsx
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 import React, { FC } from "react";
-import { ErrorNotification, Icon, Loading } from "@scm-manager/ui-components";
+import { Icon, Loading } from "@scm-manager/ui-components";
 import { useCollapsedState, useIsCategoryDisabled } from "../config/hooks";
 import { Link } from "@scm-manager/ui-types";
 import CollapsibleContainer from "../CollapsibleContainer";
@@ -32,7 +32,8 @@ import classNames from "classnames";
 import styled from "styled-components";
 import { useLoginInfo } from "@scm-manager/ui-api";
 
-const withSourceQueryParam = (url: string) => stringifyUrl({ url, query: { source: "landingpage-feature-tile" } });
+const withSourceQueryParam = (url?: string) =>
+  url && stringifyUrl({ url, query: { source: "landingpage-feature-tile" } });
 
 const StyledAnchor = styled.a`
   color: inherit;
@@ -48,15 +49,11 @@ const MyTips: FC = () => {
     return null;
   }
 
-  if (error) {
-    return <ErrorNotification error={error} />;
-  }
-
   if (isLoading) {
     return <Loading />;
   }
 
-  if (!loginInfo?.feature) {
+  if (!loginInfo?.feature && !error) {
     return null;
   }
 
@@ -67,9 +64,10 @@ const MyTips: FC = () => {
       count={1}
       initiallyCollapsed={collapsed}
       onCollapseToggle={setCollapsed}
+      error={error}
     >
       <StyledAnchor
-        href={withSourceQueryParam((loginInfo.feature._links.self as Link).href)}
+        href={withSourceQueryParam((loginInfo?.feature?._links.self as Link | undefined)?.href)}
         className="p-2 media has-hover-background-blue"
       >
         <figure className="media-left mr-2 mt-1">
@@ -85,8 +83,8 @@ const MyTips: FC = () => {
             "is-align-self-stretch"
           )}
         >
-          <strong className="is-marginless">{loginInfo.feature.title}</strong>
-          <small>{loginInfo.feature.summary}</small>
+          <strong className="is-marginless">{loginInfo?.feature?.title}</strong>
+          <small>{loginInfo?.feature?.summary}</small>
         </div>
       </StyledAnchor>
     </CollapsibleContainer>


### PR DESCRIPTION
## Proposed changes

When data fetching for tiles in the landing page fails, an error notification is rendered in place of the whole tile, instead of within the file. Also, the user is not redirected to the landing page after changing which tiles should be displayed on the settings page. This behaviour is common in the SCM-Manager. Both of these issues have been fixed in this PR.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [x] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [x] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
