### PR TITLE
add extra property to mydata extension point

### DIFF
--- a/src/main/js/data/MyData.tsx
+++ b/src/main/js/data/MyData.tsx
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import React, { FC, ReactElement } from "react";
+import React, { FC, ReactElement, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useIndexLinks } from "@scm-manager/ui-api";
 import { Loading, Notification } from "@scm-manager/ui-components";
@@ -35,6 +35,7 @@ import { MyDataType } from "../types";
 export type ExtensionProps = {
   title: string;
   render: (data: any, key: any) => ReactElement;
+  beforeData?: ReactNode;
   separatedEntries: boolean;
   type: string;
   emptyMessage?: string;
@@ -64,6 +65,7 @@ const MyDataExtension: FC<MyDataExtensionProps> = ({ extension, data, error }) =
         onCollapseToggle={setCollapsed}
         error={error}
       >
+        {extension.beforeData}
         {(data?.length || 0) > 0 ? (
           data?.map((dataEntry, key) => <>{extension.render(dataEntry, key)}</>)
         ) : (


### PR DESCRIPTION
## Proposed changes

A new feature in the review plugin requires content to be displayed before the list for a data tile. This PR adds a new property to the already existing extension point for data widgets that lets a developer render content inside a widget before the data items are rendered.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [ ] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
